### PR TITLE
Reset buffer after stopping the reader

### DIFF
--- a/src/devices/sdrplay-handler-v3/sdrplay-handler-v3.cpp
+++ b/src/devices/sdrplay-handler-v3/sdrplay-handler-v3.cpp
@@ -218,6 +218,7 @@ void SdrPlayHandler_v3::stopReader()
     return;
   }
   messageHandler(&r);
+  resetBuffer();
 }
 
 //


### PR DESCRIPTION
RSP sends a lot of data from the old frequency after a frequency change.