### PR TITLE
More accurate estimate of coarse frequency correction

### DIFF
--- a/src/main/dab-processor.cpp
+++ b/src/main/dab-processor.cpp
@@ -211,7 +211,7 @@ void DabProcessor::_state_process_rest_of_frame(i32 & ioSampleCount)
 
     if (correction != PhaseReference::IDX_NOT_FOUND)
     {
-      mFreqOffsSyncSymb += (f32)correction * (f32)cCarrDiff;
+      mFreqOffsSyncSymb += (f32)correction;
 
       if (std::abs(mFreqOffsSyncSymb) > kHz(35))
       {

--- a/src/ofdm/phasereference.cpp
+++ b/src/ofdm/phasereference.cpp
@@ -44,7 +44,7 @@
   *	The class inherits from the phaseTable.
   */
 
-#define COARSE_FRQUENCY_CORRECTION 3
+#define COARSE_FRQUENCY_CORRECTION 2
 
 PhaseReference::PhaseReference(const DabRadio * const ipRadio, const ProcessParams * const ipParam)
   : PhaseTable()
@@ -59,21 +59,18 @@ PhaseReference::PhaseReference(const DabRadio * const ipRadio, const ProcessPara
   std::fill(mMeanCorrPeakValues.begin(), mMeanCorrPeakValues.end(), 0.0f);
 
   // Prepare a table for the coarse frequency synchronization.
-  // We collect data of SEARCHRANGE/2 bins at the end of the FFT buffer and wrap to the begin and check SEARCHRANGE/2 elements further.
-  // This is equal to check +/- SEARCHRANGE/2 bins (== (35) kHz in DabMode 1) around the DC
 #if COARSE_FRQUENCY_CORRECTION == 0 // Old code from Qt-Dab
   for (i32 i = 1; i <= DIFFLENGTH; i++)
   {
-    mPhaseDifferences[i - 1] = abs(arg(mRefTable[(cTu + i + 0) % cTu] * conj(mRefTable[(cTu + i + 1) % cTu])));
+    mPhaseDifferences[i - 1] = abs(arg(mRefTable[(cTu + i) % cTu] * conj(mRefTable[(cTu + i + 1) % cTu])));
   }
-#elif COARSE_FRQUENCY_CORRECTION == 1 // From Welle.io
+#elif COARSE_FRQUENCY_CORRECTION == 1
   mRefArg.resize(CORRELATION_LENGTH);
   for (i32 i = 0; i < CORRELATION_LENGTH; i++)
   {
     mRefArg[i] = arg(mRefTable[(cTu + i) % cTu] * conj(mRefTable[(cTu + i + 1) % cTu]));
   }
-  mCorrelationVector.resize(SEARCHRANGE + CORRELATION_LENGTH);
-#elif COARSE_FRQUENCY_CORRECTION == 3 // Code from DAB-Radio
+#elif COARSE_FRQUENCY_CORRECTION == 2 // Code from DAB-Radio
   refArg.resize(cTu);
   CalculateRelativePhase(mRefTable.data(), mFftInBuffer);
   fftwf_execute(mFftPlanBwd);
@@ -217,23 +214,25 @@ i32 PhaseReference::correlate_with_phase_ref_and_find_max_peak(const TArrayTn & 
 }
 
 //	an approach that works fine is to correlate the phase differences between subsequent carriers
-i16 PhaseReference::estimate_carrier_offset_from_sync_symbol_0(const TArrayTu & iV)
+i32 PhaseReference::estimate_carrier_offset_from_sync_symbol_0(const TArrayTu & iV)
 {
 
 #if COARSE_FRQUENCY_CORRECTION == 0 // Old code from Qt-Dab
 
+  std::array<f32, SEARCHRANGE + DIFFLENGTH + 1> computedDiffs{};
   const i16 idxStart = cTu - SEARCHRANGE / 2;
   const i16 idxStop  = cTu + SEARCHRANGE / 2;
-  f32 mmin =  1000.0;
-  f32 mmax = -1000.0;
+  f32 min = 1000;
+  f32 max = 0;
   i16 idxMin = IDX_NOT_FOUND;
   i16 idxMax = IDX_NOT_FOUND;
 
-  // We collect data of SEARCHRANGE/2 bins at the end of the FFT buffer and wrap to the begin and check SEARCHRANGE/2 elements further.
-  // This is equal to check +/- SEARCHRANGE/2 bins (== kHz in DabMode 1) around the DC
+  // We collect data of SEARCHRANGE/2 bins at the end of the FFT buffer and wrap to the
+  // begin and check SEARCHRANGE/2 elements further.
+  // This is equal to check +/- SEARCHRANGE/2 bins (== kHz in DabMode 1) around the DC.
   for (i16 i = idxStart; i < idxStop + DIFFLENGTH; i++)
   {
-    mComputedDiffs[i - idxStart] = std::abs(arg(iV[(i + 0) % cTu] * conj(iV[(i + 1) % cTu])));
+    computedDiffs[i - idxStart] = abs(arg(iV[i % cTu] * conj(iV[(i + 1) % cTu])));
   }
   for (i16 i = idxStart; i < idxStop; i++)
   {
@@ -245,21 +244,21 @@ i16 PhaseReference::estimate_carrier_offset_from_sync_symbol_0(const TArrayTu & 
     {
       if (mPhaseDifferences[j - 1] < 0.1f)
       {
-        sumMinValues += mComputedDiffs[i - idxStart + j];
+        sumMinValues += computedDiffs[i - idxStart + j];
       }
       else if (mPhaseDifferences[j - 1] > F_M_PI - 0.1f)
       {
-        sumMaxValues += mComputedDiffs[i - idxStart + j];
+        sumMaxValues += computedDiffs[i - idxStart + j];
       }
     }
-    if (sumMinValues < mmin)
+    if (sumMinValues < min)
     {
-      mmin = sumMinValues;
+      min = sumMinValues;
       idxMin = i;
     }
-    if (sumMaxValues > mmax)
+    if (sumMaxValues > max)
     {
-      mmax = sumMaxValues;
+      max = sumMaxValues;
       idxMax = i;
     }
   }
@@ -267,9 +266,11 @@ i16 PhaseReference::estimate_carrier_offset_from_sync_symbol_0(const TArrayTu & 
   {
     return IDX_NOT_FOUND;
   }
-  return idxMin - cTu;  // return the offset around cTu
+  const i32 offset = idxMin - cTu; // return the offset around cTu
+  //fprintf(stderr, "min=%.0f, max=%.0f, offset=%d\n", min, max, offset);
+  return offset * cCarrDiff;
 
-#elif COARSE_FRQUENCY_CORRECTION == 1 // CorrelatePRS from Welle.io
+#elif COARSE_FRQUENCY_CORRECTION == 1 // modified Code
 
   //  The "best" approach for computing the coarse frequency offset is to
   //  look at the spectrum of symbol 0 and relate that with the spectrum as
@@ -279,60 +280,45 @@ i16 PhaseReference::estimate_carrier_offset_from_sync_symbol_0(const TArrayTu & 
   //  differences between the subsequent carriers rather than the values in
   //  the segments themselves. It seems to work pretty well.
   //  The phase differences are computed once
+  f32 correlationVector[SEARCHRANGE + CORRELATION_LENGTH];
+  i16 index = IDX_NOT_FOUND;
+  f32 min = 1000;
+
   for (i16 i = 0; i < SEARCHRANGE + CORRELATION_LENGTH; ++i)
   {
     const i16 baseIndex = cTu - SEARCHRANGE / 2 + i;
-    mCorrelationVector[i] = arg(iV[baseIndex % cTu] * conj(iV[(baseIndex + 1) % cTu]));
+    correlationVector[i] = arg(iV[baseIndex % cTu] * conj(iV[(baseIndex + 1) % cTu]));
   }
-  i16 index = IDX_NOT_FOUND;
-  f32 max = 0;
+  //fprintf(stderr, "Sum = ");
   for (i16 i = 0; i < SEARCHRANGE; i++)
   {
     f32 sum = 0;
     for (i16 j = 0; j < CORRELATION_LENGTH; ++j)
     {
-      sum += abs(mRefArg[j] * mCorrelationVector[i + j]);
-      if (sum > max)
-      {
-        max = sum;
-        index = i;
-      }
+      f32 value = abs(mRefArg[j] - correlationVector[i + j]);
+      if (value > F_M_PI) value = abs(value - F_2_M_PI);
+      if (j == 0) value = 0;  // Carrier 0 doesn't exist
+      sum += value;
     }
-  }
-  // Now map the index back to the right carrier
-  return index - SEARCHRANGE / 2;
-
-#elif COARSE_FRQUENCY_CORRECTION == 2 // PatternOfZeros from Welle.io
-
-  // An alternative way is to look at a special pattern consisting
-  // of zeros in the row of args between successive carriers.
-  f32 min   = 1000;
-  i16 index = IDX_NOT_FOUND;
-  for (i16 i = cTu - SEARCHRANGE / 2; i < cTu + SEARCHRANGE / 2; i ++)
-  {
-    f32 a1 = abs(abs(arg(iV[(i + 1) % cTu] * conj(iV[(i + 2) % cTu])) / M_PI) - 1);
-    f32 a2 = abs(abs(arg(iV[(i + 2) % cTu] * conj(iV[(i + 3) % cTu])) / M_PI) - 1);
-    f32 a3 = abs(arg(iV[(i + 3) % cTu] * conj(iV[(i + 4) % cTu])));
-    f32 a4 = abs(arg(iV[(i + 4) % cTu] * conj(iV [(i + 5) % cTu])));
-    f32 a5 = abs(arg(iV[(i + 5) % cTu] * conj(iV[(i + 6) % cTu])));
-    f32 b1 = abs(abs(arg(iV[(i + 16 + 1) % cTu] * conj(iV[(i + 16 + 3) % cTu])) / M_PI) - 1);
-    f32 b2 = abs(arg(iV[(i + 16 + 3) % cTu] * conj(iV[(i + 16 + 4) % cTu])));
-    f32 b3 = abs(arg(iV[(i + 16 + 4) % cTu] * conj(iV[(i + 16 + 5) % cTu])));
-    f32 b4 = abs(arg(iV[(i + 16 + 5) % cTu] * conj(iV[(i + 16 + 6) % cTu])));
-    f32 sum = a1 + a2 + a3 + a4 + a5 + b1 + b2 + b3 + b4;
     if (sum < min)
     {
       min = sum;
       index = i;
     }
+    //fprintf(stderr, "%.0f ", sum);
   }
-  return index - cTu;
+  //fprintf(stderr, "\n");
 
-#elif COARSE_FRQUENCY_CORRECTION == 3 // Code from DAB-Radio
+  // Now map the index back to the right carrier
+  const i32 offset = index - SEARCHRANGE / 2;
+  //fprintf(stderr, "min=%.0f, offset=%d\n", min, offset);
+  return offset * cCarrDiff;
 
-  i16 index = IDX_NOT_FOUND;
+#elif COARSE_FRQUENCY_CORRECTION == 2 // Code from DAB-Radio
+
   f32 correlationVector[cTu];
-  f32 max_value = 0;
+  i16 index = IDX_NOT_FOUND;
+  f32 max = 0;
 
   // Step 2: Get complex difference between consecutive bins
   CalculateRelativePhase(iV.data(), mFftInBuffer);
@@ -344,7 +330,7 @@ i16 PhaseReference::estimate_carrier_offset_from_sync_symbol_0(const TArrayTu & 
   //         NOTE: refArg is already the conjugate
   for (i32 i = 0; i < cTu; i++)
   {
-    mFftInBuffer[i] = mFftOutBuffer[i] *= refArg[i];
+    mFftInBuffer[i] = mFftOutBuffer[i] * refArg[i];
   }
 
   // Step 5: Get FFT to get correlation in frequency domain
@@ -355,19 +341,34 @@ i16 PhaseReference::estimate_carrier_offset_from_sync_symbol_0(const TArrayTu & 
 
   // Step 7: Find the peak in our maximum coarse frequency error window
   //         NOTE: A zero frequency error corresponds to a peak at cTu/2
+  //fprintf(stderr, "Sum = ");
   for (i32 i = -SEARCHRANGE/2; i <= SEARCHRANGE/2; i++)
   {
     const i32 fft_index = cTu/2 + i;
-    if (fft_index == cTu) continue;
     const f32 value = correlationVector[fft_index];
-    if (value > max_value)
+    if (value > max)
     {
-      max_value = value;
+      max = value;
       index = i;
     }
+    //fprintf(stderr, "%.0f ", value/10000000);
   }
-  return index;
+  //fprintf(stderr, "\n");
 
+  // Step 8: Determine the coarse frequency offset
+  // We get the frequency offset in terms of FFT bins which we convert to normalised Hz
+  // Interpolate peak between neighbouring fft bins based on magnitude for more accurate estimate
+  f32 peak[3];
+  f32 peak_sum = 0.0f;
+  for(int i = 0; i<3; i++)
+  {
+    const i32 fft_index = cTu/2 + i + index - 1;
+    peak[i] = correlationVector[fft_index];
+    peak_sum += peak[i];
+  }
+  const f32 offset = index + (peak[2] - peak[0]) / peak_sum;
+  //fprintf(stderr, "max=%.0f, offset=%f\n", max/10000000, offset);
+  return (int32_t)(offset * cCarrDiff);
 #endif
 }
 

--- a/src/ofdm/phasereference.h
+++ b/src/ofdm/phasereference.h
@@ -52,22 +52,27 @@ public:
   ~PhaseReference() override;
 
   [[nodiscard]] i32 correlate_with_phase_ref_and_find_max_peak(const TArrayTn & iV, const f32 iThreshold);
-  [[nodiscard]] i16 estimate_carrier_offset_from_sync_symbol_0(const TArrayTu & iV);
+  [[nodiscard]] i32 estimate_carrier_offset_from_sync_symbol_0(const TArrayTu & iV);
   [[nodiscard]] static f32 phase(const std::vector<cf32> & iV, i32 iTs);
   void set_sync_on_strongest_peak(bool sync);
 
   static constexpr i16 IDX_NOT_FOUND = 10000;
 
 private:
-  static constexpr i16 SEARCHRANGE = (2 * 35);
-  static constexpr i16 CORRELATION_LENGTH = 48;
-  static constexpr i16 DIFFLENGTH = 128;
-  std::array<f32, SEARCHRANGE + DIFFLENGTH + 1> mComputedDiffs{};
+  static constexpr i16 SEARCHRANGE = (2 * 36);
+
+  // COARSE_FRQUENCY_CORRECTION 0
+  static constexpr int16_t DIFFLENGTH = 128;
   std::array<f32, DIFFLENGTH> mPhaseDifferences;
+
+  // COARSE_FRQUENCY_CORRECTION 1
+  static constexpr i16 CORRELATION_LENGTH = 48;
+  std::vector<f32> mRefArg;
+
+  // COARSE_FRQUENCY_CORRECTION 2
   void CalculateRelativePhase(const cf32 *fft_in, TArrayTu & arg_out);
   void CalculateMagnitude(const TArrayTu & fft_buf, f32 *mag_buf);
   std::vector<cf32> refArg;
-  std::vector<f32> mRefArg;
 
   const i32 mFramesPerSecond;
   i32 mDisplayCounter = 0;
@@ -81,7 +86,6 @@ private:
   RingBuffer<f32> * const mpResponse;
   std::vector<f32> mCorrPeakValues;
   std::vector<f32> mMeanCorrPeakValues;
-  std::vector<f32> mCorrelationVector;
 
 signals:
   void signal_show_correlation(f32, const QVector<i32> &);


### PR DESCRIPTION
Interpolate between neighbouring peaks to increase precision. Delete two altenative codes and add a better one.