### PR TITLE
Show all internet links in Jounaline

### DIFF
--- a/src/backend/data/journaline-datahandler.cpp
+++ b/src/backend/data/journaline-datahandler.cpp
@@ -104,9 +104,9 @@ void JournalineDataHandler::add_to_dataBase(const NML * const ipNmlElement)
   switch (ipNmlElement->GetObjectType())
   {
   case NML::INVALID:
-  case NML::TITLE: // this is implicitly handled with the List, Plain text or Menu
     return;
 
+  case NML::TITLE: // this is implicitly handled with the List, Plain text or Menu
   case NML::MENU:
   case NML::PLAIN:
   case NML::LIST:

--- a/src/backend/data/journaline-viewer.cpp
+++ b/src/backend/data/journaline-viewer.cpp
@@ -39,7 +39,7 @@ JournalineViewer::JournalineViewer(TMapData & ioTableVec, const i32 iSubChannel)
                                "For more information visit "
                                "<a href=\"http://www.iis.fhg.de/dab\" style=\"color: #87CEFA;\">http://www.iis.fhg.de/dab</a>"
                                "</span>";
-  
+
   const QString legendStr = "<table style=\"border-collapse: collapse; font-size: small;\">"
                             "<tr>"
                             "<td colspan=\"2\" style=\"padding-bottom: 5px;\"><span style=\"color: lightgray;\">Menu legend:</span></td>"
@@ -53,7 +53,7 @@ JournalineViewer::JournalineViewer(TMapData & ioTableVec, const i32 iSubChannel)
                             "<td><span style=\"color: " + cColorVisited   + ";\">&nbsp;Element closed but visited before&nbsp;</span></td>"
                             "</tr>"
                             "</table>";
-  
+
   mpTimerRecMarker = new QTimer(this);
   mpTimerRecMarker->setSingleShot(true);
   mpTimerRecMarker->setInterval(100);
@@ -168,7 +168,7 @@ void JournalineViewer::_slot_html_link_activated(const QString & iLink)
     it.value().isOpened = !it.value().isOpened;
     it.value().wasVisited = true;
   }
-  
+
   // Refresh HTML view
   if (mDataMap.contains(0))
   {
@@ -190,12 +190,6 @@ void JournalineViewer::_build_html_tree_recursive(const TMapData::iterator & iIt
   else if (!iSuppressTitle)
   {
     ioHtml += capTagBeg + QString::fromUtf8(pElem->title) + capTagEnd;
-  }
-
-  if (!pElem->html.empty())
-  {
-    const QString htmlDec = QString::fromUtf8(pElem->html); // not sure how it is really sent but "umlauts" are allowed since some time in an URL
-    ioHtml += "<a style=\"color: lightcoral;\" href=\"" + htmlDec + "\">" + htmlDec + "</a>";
   }
 
   switch (pElem->object_type)
@@ -249,6 +243,37 @@ void JournalineViewer::_build_html_tree_recursive(const TMapData::iterator & iIt
     break;
   default:
     break;
+  }
+  if (!pElem->html.empty())
+  {
+    const QString htmlDec = QString::fromUtf8(pElem->html); // not sure how it is really sent but "umlauts" are allowed since some time in an URL
+    const int len = htmlDec.size();
+    int pos = 0;
+    int i;
+    ioHtml += "<p>";
+    while(pos < len)
+    {
+      QString url;
+      for(i=0; i<len; i++)
+      {
+        if (htmlDec[pos] == 0)
+          break;
+        url += htmlDec[pos];
+        pos++;
+	  }
+      pos++;
+      QString text;
+      for(i=0; i<len; i++)
+      {
+        if (htmlDec[pos] == 0)
+          break;
+        text += htmlDec[pos];
+        pos++;
+      }
+      pos++;
+      ioHtml += "<a style=\"color: lightcoral;\" href=\"" + url + "\">" + text + "</a><br>";
+    }
+    ioHtml += "</p>";
   }
 }
 

--- a/src/backend/data/journaline/NML.cpp
+++ b/src/backend/data/journaline/NML.cpp
@@ -304,11 +304,11 @@ unsigned char * NMLFactory::getNextSection(const unsigned char *& p, unsigned sh
 
 void NMLFactory::append_link_data_from_raw_news_object(std::string & ioLinkData, const unsigned char * ipInData, int iDsLen) const
 {
-  if (iDsLen > 4 && ((ipInData[0] == 0x1a && ipInData[2] == 0x03 && ipInData[3] == 0x02 && ioLinkData.empty()) ||
-                     (ipInData[0] == 0x1b && !ioLinkData.empty())))
+  if (iDsLen > 4 && ((ipInData[0] == 0x1a && ipInData[2] == 0x03 && ipInData[3] == 0x02) || (ipInData[0] == 0x1b)))
   {
-    ioLinkData.append(reinterpret_cast<const char *>(ipInData + 4));
-    // ioLinkData.append(reinterpret_cast<const char *>(ipInData + 4), iDsLen - 4);
+    if (ipInData[0] == 0x1a && !ioLinkData.empty())
+      ioLinkData += char(0);
+    ioLinkData.append(reinterpret_cast<const char *>(ipInData + 4), iDsLen - 2);
   }
 }
 
@@ -454,13 +454,6 @@ NML * NMLFactory::CreateNML(const NML::RawNewsObject_t & rno, const NMLEscapeCod
   if (!linkData.empty())
   {
     // qDebug().noquote() << "Linkdata:" << linkData;
-
-    // workaround as some links seems corrupt
-    if (linkData.find("https://", 8) != std::string::npos) // this cannot be found in a normal link text
-    {
-      qDebug() << "Link data contains faulty http link (ignored):" << linkData;
-      linkData.clear(); // we will delete the full link string to get sure not misusing it
-    }
     n->_news.html = std::move(linkData);
   }
 


### PR DESCRIPTION
Move internet links to the end of the text
Show description text instead of URL
Show all internet links, not only the first one
Mark title green, if an internet link is received