### PR TITLE
Make TII accumulation time independent of the signal level

### DIFF
--- a/src/base/ofdm/tii_detector.cpp
+++ b/src/base/ofdm/tii_detector.cpp
@@ -232,12 +232,6 @@ std::vector<STiiResult> TiiDetector::process_tii_data(const i16 iThreshold_db)
     }
   }
 
-  // reduce TII values of "old" data (> about 2 minutes collection) to allow new TII data to be more present
-  if (max > 4'000'000)
-  {
-    for (auto & db : mDecodedBufferArr) db *= 0.9f;
-  }
-
   _reset_null_symbol_buffer();
 
   // Sort the elements according to their strength
@@ -257,7 +251,8 @@ void TiiDetector::_decode_and_accumulate_carrier_pairs(TBufferArr768 & ioVec, co
   {
     const i32 fftIdx = fft_shift_skip_dc<cTu>(k);
     const cf32 prod = iVec[fftIdx] * conj(iVec[fftIdx + 1]); // TII carriers are given in pairs
-    ioVec[i] += prod;
+    // reduce TII values of "old" data (> about 2 minutes collection) to allow new TII data to be more present
+    mean_filter(ioVec[i], prod, 0.01f);
 
 #if 0
     if (std::abs(prod) > 1000.0f)

--- a/src/common/glob_defs.h
+++ b/src/common/glob_defs.h
@@ -214,7 +214,7 @@ template<typename T> inline T calc_adaptive_alpha(const T iAlphaBegin, const T i
   return alpha;
 }
 
-template<typename T> inline void mean_filter(T & ioVal, const T iVal, const T iAlpha)
+template<typename T> inline void mean_filter(T & ioVal, const T iVal, const f32 iAlpha)
 {
   ioVal += iAlpha * (iVal - ioVal);
 }


### PR DESCRIPTION
Unlike RTL-SDRs, RSPs cannot be driven to full scale because their ADC becomes non-linear in that state. For this reason, the collection time for TII data was much longer.